### PR TITLE
fixed the way env vars are being exported

### DIFF
--- a/lib/vx/citool/stage.rb
+++ b/lib/vx/citool/stage.rb
@@ -44,8 +44,8 @@ module Vx
               log_value = value
             end
 
+            a.invoke_shell("export #{name}=#{value}", hidden: true)
             log_command "export #{name}=#{log_value}"
-            ENV[name] = value
           end
 
           invoke_tasks

--- a/spec/lib/citool/stage_spec.rb
+++ b/spec/lib/citool/stage_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Vx::Citool::Stage do
+  let(:environment) do
+    {
+      "TEST_EXPAND" => "~",
+      "TEST_SECRET" => "!secret",
+      "TEST_ENV"    => "test_env"
+    }
+  end
+
+  subject {
+    described_class.new("environment" => environment).invoke
+  }
+
+  context "environment" do
+    before { subject }
+
+    it "expands env" do
+      expect(ENV['TEST_EXPAND']).to match(/#{ENV['USER']}\z/)
+    end
+
+    it "adds secret env" do
+      expect(ENV['TEST_SECRET']).to eq "secret"
+    end
+
+    it "adds env" do
+      expect(ENV['TEST_ENV']).to eq "test_env"
+    end
+  end
+end


### PR DESCRIPTION
ENV[k] = v hasn't expanded paths properly